### PR TITLE
feat: remove provider being passed for contract calls

### DIFF
--- a/common-util/Contracts/index.jsx
+++ b/common-util/Contracts/index.jsx
@@ -62,17 +62,18 @@ export const getContractAddress = (type, chainIdPassed) => {
     }
   }
 };
+
+/**
+ * web3 provider =
+ * - wallect-connect provider or
+ * - currentProvider by metamask or
+ * - fallback to remote mainnet [remote node provider](https://web3js.readthedocs.io/en/v1.7.5/web3.html#example-remote-node-provider)
+ */
 export const getMyProvider = () => window.MODAL_PROVIDER
   || window.web3?.currentProvider
   || process.env.NEXT_PUBLIC_MAINNET_URL;
 
 export const getWeb3Details = () => {
-  /**
-   * web3 provider =
-   * - wallect-connect provider or
-   * - currentProvider by metamask or
-   * - fallback to remote mainnet [remote node provider](https://web3js.readthedocs.io/en/v1.7.5/web3.html#example-remote-node-provider)
-   */
   const web3 = new Web3(getMyProvider());
   const chainId = getChainId() || 1; // default to mainnet
   return { web3, chainId };

--- a/common-util/Contracts/index.jsx
+++ b/common-util/Contracts/index.jsx
@@ -1,4 +1,5 @@
 import Web3 from 'web3';
+import { getChainId } from '@autonolas/frontend-library';
 import {
   // Olas
   OLAS_ABI_GOERLI,
@@ -35,7 +36,9 @@ export const LOCAL_ADDRESSES = {
  * Right now, only 3 types are supported: olas, veOlas, buOlas
  * and 3 chains: local, goerli and mainnet.
  */
-export const getContractAddress = (type, chainId) => {
+export const getContractAddress = (type, chainIdPassed) => {
+  const chainId = chainIdPassed || getChainId() || 1; // default to mainnet
+
   switch (type) {
     case 'veOlas': {
       if (chainId === LOCAL_CHAIN_ID) {
@@ -59,30 +62,45 @@ export const getContractAddress = (type, chainId) => {
     }
   }
 };
+export const getMyProvider = () => window.MODAL_PROVIDER
+  || window.web3?.currentProvider
+  || process.env.NEXT_PUBLIC_MAINNET_URL;
 
-export const getOlasContract = (p, chainId) => {
-  const web3 = new Web3(p);
+export const getWeb3Details = () => {
+  /**
+   * web3 provider =
+   * - wallect-connect provider or
+   * - currentProvider by metamask or
+   * - fallback to remote mainnet [remote node provider](https://web3js.readthedocs.io/en/v1.7.5/web3.html#example-remote-node-provider)
+   */
+  const web3 = new Web3(getMyProvider());
+  const chainId = getChainId() || 1; // default to mainnet
+  return { web3, chainId };
+};
+
+export const getOlasContract = () => {
+  const { web3, chainId } = getWeb3Details();
   const contract = new web3.eth.Contract(
     chainId === 1 ? OLAS_ABI_MAINNET : OLAS_ABI_GOERLI,
-    getContractAddress('olas', chainId),
+    getContractAddress('olas'),
   );
   return contract;
 };
 
-export const getVeolasContract = (p, chainId) => {
-  const web3 = new Web3(p);
+export const getVeolasContract = () => {
+  const { web3, chainId } = getWeb3Details();
   const contract = new web3.eth.Contract(
     chainId === 1 ? VEOLAS_ABI_MAINNET : VEOLAS_ABI_GOERLI,
-    getContractAddress('veOlas', chainId),
+    getContractAddress('veOlas'),
   );
   return contract;
 };
 
-export const getBuolasContract = (p, chainId) => {
-  const web3 = new Web3(p);
+export const getBuolasContract = () => {
+  const { web3, chainId } = getWeb3Details();
   const contract = new web3.eth.Contract(
     chainId === 1 ? BUOLAS_ABI_MAINNET : BUOLAS_ABI_GOERLI,
-    getContractAddress('buOlas', chainId),
+    getContractAddress('buOlas'),
   );
   return contract;
 };

--- a/components/Home/BuOlas/components/AddToLock.jsx
+++ b/components/Home/BuOlas/components/AddToLock.jsx
@@ -15,7 +15,6 @@ export const BuolasCreateLock = () => {
 
       const txHash = await createBuolasLockRequest({
         account,
-        chainId,
       });
       notifySuccess(
         'Lock created successfully!',

--- a/components/Home/BuOlas/components/BuolasManage.jsx
+++ b/components/Home/BuOlas/components/BuolasManage.jsx
@@ -30,7 +30,7 @@ export const BuolasManage = () => {
   // uncomment this to revoke all vested amount (just for testing)
   // useEffect(() => {
   //   if (account && chainId) {
-  //     revokeRequest({ account, chainId });
+  //     revokeRequest({ account });
   //   }
   // }, [account, chainId]);
 
@@ -38,7 +38,7 @@ export const BuolasManage = () => {
     if (account && chainId) {
       setIsWithdrawLoading(true);
       try {
-        await withdrawRequest({ account, chainId });
+        await withdrawRequest({ account });
         notifySuccess('Claimed successfully!');
 
         // fetch all the data again to update

--- a/components/Home/BuOlas/contractUtils.jsx
+++ b/components/Home/BuOlas/contractUtils.jsx
@@ -9,7 +9,7 @@ import { MAX_AMOUNT, parseEther } from 'common-util/functions';
 const SIGNER_ADDRESS = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
 
 export const approveOlasByOwner = ({ account, chainId }) => new Promise((resolve, reject) => {
-  const contract = getOlasContract(window.MODAL_PROVIDER, chainId);
+  const contract = getOlasContract();
   const spender = getContractAddress('buOlas', chainId);
 
   const fn = contract.methods
@@ -30,8 +30,8 @@ export const approveOlasByOwner = ({ account, chainId }) => new Promise((resolve
  * create lock for buOlas
  * NOTE: this is a internal method and won't be exposed or visible to the user
  */
-export const createBuolasLockRequest = ({ account, chainId }) => new Promise((resolve, reject) => {
-  const contract = getBuolasContract(window.MODAL_PROVIDER, chainId);
+export const createBuolasLockRequest = ({ account }) => new Promise((resolve, reject) => {
+  const contract = getBuolasContract();
 
   // creating lock for the signer with 100 ETH & locked for 4 years.
   // address is fetched when BE is connected locally
@@ -56,8 +56,8 @@ export const createBuolasLockRequest = ({ account, chainId }) => new Promise((re
 /**
  * Withdraw buOlas
  */
-export const withdrawRequest = ({ account, chainId }) => new Promise((resolve, reject) => {
-  const contract = getBuolasContract(window.MODAL_PROVIDER, chainId);
+export const withdrawRequest = ({ account }) => new Promise((resolve, reject) => {
+  const contract = getBuolasContract();
 
   const fn = contract.methods.withdraw().send({ from: account });
 
@@ -72,8 +72,8 @@ export const withdrawRequest = ({ account, chainId }) => new Promise((resolve, r
 /**
  * Revoke buOlas from owner accout
  */
-export const revokeRequest = ({ account, chainId }) => new Promise((resolve, reject) => {
-  const contract = getBuolasContract(window.MODAL_PROVIDER, chainId);
+export const revokeRequest = ({ account }) => new Promise((resolve, reject) => {
+  const contract = getBuolasContract();
 
   const fn = contract.methods
     .revoke([SIGNER_ADDRESS])

--- a/components/Home/VeOlas/components/GetMoreVeolas.jsx
+++ b/components/Home/VeOlas/components/GetMoreVeolas.jsx
@@ -40,7 +40,6 @@ export const GetMoreVeolas = ({ isModalVisible, setIsModalVisible }) => {
       amount: parseToWei(form.getFieldValue('amount')),
       unlockTime: parseToSeconds(form.getFieldValue('unlockTime')),
       account,
-      chainId,
     });
     notifySuccess('Lock created successfully!', `Transaction Hash: ${txHash}`);
 

--- a/components/Home/VeOlas/components/IncreaseAmount.jsx
+++ b/components/Home/VeOlas/components/IncreaseAmount.jsx
@@ -11,7 +11,6 @@ export const IncreaseAmount = ({ closeModal }) => {
   const [form] = Form.useForm();
   const {
     account,
-    chainId,
     olasBalanceInEth,
     isMappedAmountZero,
     hasNoOlasBalance,
@@ -31,7 +30,6 @@ export const IncreaseAmount = ({ closeModal }) => {
       const txHash = await updateIncreaseAmount({
         amount: parseToWei(amount),
         account,
-        chainId,
       });
       notifySuccess(
         'Amount increased successfully!',

--- a/components/Home/VeOlas/components/IncreaseUnlockTime.jsx
+++ b/components/Home/VeOlas/components/IncreaseUnlockTime.jsx
@@ -10,7 +10,7 @@ import { FormContainer } from '../styles';
 export const IncreaseUnlockTime = ({ closeModal }) => {
   const [form] = Form.useForm();
   const {
-    account, chainId, mappedEndTime, isMappedAmountZero, getData,
+    account, mappedEndTime, isMappedAmountZero, getData,
   } = useFetchBalances();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -20,7 +20,6 @@ export const IncreaseUnlockTime = ({ closeModal }) => {
       const txHash = await updateIncreaseUnlockTime({
         time: parseToSeconds(e.unlockTime),
         account,
-        chainId,
       });
       notifySuccess(
         'Unlock time increased successfully!',

--- a/components/Home/VeOlas/components/TransferOlas.jsx
+++ b/components/Home/VeOlas/components/TransferOlas.jsx
@@ -5,13 +5,12 @@ import { useFetchBalances } from '../hooks';
 import { transferOlasToAccountRequest } from '../contractUtils';
 
 export const TransferOlas = () => {
-  const { account, chainId, getData } = useFetchBalances();
+  const { account, getData } = useFetchBalances();
 
   const transferHelper = async (signer) => {
     try {
       await transferOlasToAccountRequest({
         account,
-        chainId,
         signer,
       });
 

--- a/components/Home/VeOlas/components/index.jsx
+++ b/components/Home/VeOlas/components/index.jsx
@@ -11,9 +11,7 @@ import { IncreaseAmount } from './IncreaseAmount';
 import { IncreaseUnlockTime } from './IncreaseUnlockTime';
 
 export const VeolasManage = ({ isModalVisible, setIsModalVisible }) => {
-  const {
-    account, chainId, canWithdrawVeolas, getData,
-  } = useFetchBalances();
+  const { account, canWithdrawVeolas, getData } = useFetchBalances();
   const {
     getBalanceComponent,
     getVotingPowerComponent,
@@ -25,7 +23,7 @@ export const VeolasManage = ({ isModalVisible, setIsModalVisible }) => {
 
   const onWithdraw = async () => {
     try {
-      await withdrawVeolasRequest({ account, chainId });
+      await withdrawVeolasRequest({ account });
       notifySuccess('Claimed successfully');
 
       // fetch all the data again to update

--- a/components/Home/VeOlas/contractUtils.jsx
+++ b/components/Home/VeOlas/contractUtils.jsx
@@ -16,8 +16,8 @@ import {
 /**
  * Increase Amount
  */
-export const updateIncreaseAmount = ({ amount, account, chainId }) => new Promise((resolve, reject) => {
-  const contract = getVeolasContract(window.MODAL_PROVIDER, chainId);
+export const updateIncreaseAmount = ({ amount, account }) => new Promise((resolve, reject) => {
+  const contract = getVeolasContract();
 
   const fn = contract.methods.increaseAmount(amount).send({ from: account });
 
@@ -32,8 +32,8 @@ export const updateIncreaseAmount = ({ amount, account, chainId }) => new Promis
 /**
  * Increase Unlock time
  */
-export const updateIncreaseUnlockTime = ({ time, account, chainId }) => new Promise((resolve, reject) => {
-  const contract = getVeolasContract(window.MODAL_PROVIDER, chainId);
+export const updateIncreaseUnlockTime = ({ time, account }) => new Promise((resolve, reject) => {
+  const contract = getVeolasContract();
 
   const fn = contract.methods
     .increaseUnlockTime(time)
@@ -53,7 +53,7 @@ export const updateIncreaseUnlockTime = ({ time, account, chainId }) => new Prom
  * [here](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20#IERC20-allowance-address-address-).
  */
 export const hasSufficientTokensRequest = ({ account, chainId }) => new Promise((resolve, reject) => {
-  const contract = getOlasContract(window.MODAL_PROVIDER, chainId);
+  const contract = getOlasContract();
   const spender = getContractAddress('veOlas', chainId);
 
   contract.methods
@@ -73,7 +73,7 @@ export const hasSufficientTokensRequest = ({ account, chainId }) => new Promise(
  * Approve amount of OLAS to be used
  */
 export const approveOlasByOwner = ({ account, chainId }) => new Promise((resolve, reject) => {
-  const contract = getOlasContract(window.MODAL_PROVIDER, chainId);
+  const contract = getOlasContract();
   const spender = getContractAddress('veOlas', chainId);
 
   const fn = contract.methods
@@ -93,10 +93,8 @@ export const approveOlasByOwner = ({ account, chainId }) => new Promise((resolve
 /**
  * Create lock
  */
-export const createLockRequest = ({
-  amount, unlockTime, account, chainId,
-}) => new Promise((resolve, reject) => {
-  const contract = getVeolasContract(window.MODAL_PROVIDER, chainId);
+export const createLockRequest = ({ amount, unlockTime, account }) => new Promise((resolve, reject) => {
+  const contract = getVeolasContract();
 
   const fn = contract.methods
     .createLock(amount, unlockTime)
@@ -115,8 +113,8 @@ export const createLockRequest = ({
 /**
  * Withdraw VeOlas
  */
-export const withdrawVeolasRequest = ({ account, chainId }) => new Promise((resolve, reject) => {
-  const contract = getVeolasContract(window.MODAL_PROVIDER, chainId);
+export const withdrawVeolasRequest = ({ account }) => new Promise((resolve, reject) => {
+  const contract = getVeolasContract();
 
   const fn = contract.methods.withdraw().send({ from: account });
 
@@ -133,8 +131,8 @@ export const withdrawVeolasRequest = ({ account, chainId }) => new Promise((reso
  * NOTE: this is a internal method for testing and
  * won't be exposed or visible to the user
  */
-export const transferOlasToAccountRequest = ({ account, chainId, signer }) => new Promise((resolve, reject) => {
-  const contract = getOlasContract(window.MODAL_PROVIDER, chainId);
+export const transferOlasToAccountRequest = ({ account, signer }) => new Promise((resolve, reject) => {
+  const contract = getOlasContract();
 
   // transfering OLAS to the signer account with 100 ETH.
   const values = {

--- a/store/setup/actions.js
+++ b/store/setup/actions.js
@@ -33,10 +33,9 @@ export const setLogout = () => ({
 // olas
 export const fetchOlasBalance = () => async (dispatch, getState) => {
   const account = getState()?.setup?.account;
-  const chainId = getState()?.setup?.chainId;
 
   try {
-    const contract = getOlasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getOlasContract();
     const response = await contract.methods
       .balanceOf(account)
       .call();
@@ -56,10 +55,9 @@ export const fetchOlasBalance = () => async (dispatch, getState) => {
  */
 export const fetchVeolasBalance = () => async (dispatch, getState) => {
   const account = getState()?.setup?.account;
-  const chainId = getState()?.setup?.chainId;
 
   try {
-    const contract = getVeolasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getVeolasContract();
     const response = await contract.methods
       .balanceOf(account)
       .call();
@@ -80,10 +78,9 @@ export const setMappedBalances = (data) => ({
 
 export const fetchMappedBalances = () => async (dispatch, getState) => {
   const account = getState()?.setup?.account;
-  const chainId = getState()?.setup?.chainId;
 
   try {
-    const contract = getVeolasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getVeolasContract();
     const response = await contract.methods
       .mapLockedBalances(account)
       .call();
@@ -102,10 +99,9 @@ export const fetchMappedBalances = () => async (dispatch, getState) => {
 
 export const fetchVotes = () => async (dispatch, getState) => {
   const account = getState()?.setup?.account;
-  const chainId = getState()?.setup?.chainId;
 
   try {
-    const contract = getVeolasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getVeolasContract();
     const response = await contract.methods
       .getVotes(account)
       .call();
@@ -119,11 +115,9 @@ export const fetchVotes = () => async (dispatch, getState) => {
   }
 };
 
-export const fetchTotalSupplyLocked = () => async (dispatch, getState) => {
-  const chainId = getState()?.setup?.chainId;
-
+export const fetchTotalSupplyLocked = () => async (dispatch) => {
   try {
-    const contract = getVeolasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getVeolasContract();
     const response = await contract.methods
       .totalSupplyLocked()
       .call();
@@ -146,10 +140,9 @@ export const fetchVeolasDetails = () => async (dispatch) => {
 
 export const fetchIfCanWithdrawVeolas = () => async (dispatch, getState) => {
   const account = getState()?.setup?.account;
-  const chainId = getState()?.setup?.chainId;
 
   try {
-    const contract = getVeolasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getVeolasContract();
     const balance = await contract.methods
       .balanceOf(account)
       .call();
@@ -174,10 +167,9 @@ export const fetchIfCanWithdrawVeolas = () => async (dispatch, getState) => {
 // buOlas
 export const fetchBuolasBalance = () => async (dispatch, getState) => {
   const account = getState()?.setup?.account;
-  const chainId = getState()?.setup?.chainId;
 
   try {
-    const contract = getBuolasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getBuolasContract();
     const response = await contract.methods
       .balanceOf(account)
       .call();
@@ -193,10 +185,9 @@ export const fetchBuolasBalance = () => async (dispatch, getState) => {
 
 export const fetchReleasableAmount = () => async (dispatch, getState) => {
   const account = getState()?.setup?.account;
-  const chainId = getState()?.setup?.chainId;
 
   try {
-    const contract = getBuolasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getBuolasContract();
     const response = await contract.methods
       .releasableAmount(account)
       .call();
@@ -213,10 +204,9 @@ export const fetchReleasableAmount = () => async (dispatch, getState) => {
 
 export const fetchMapLockedBalances = () => async (dispatch, getState) => {
   const account = getState()?.setup?.account;
-  const chainId = getState()?.setup?.chainId;
 
   try {
-    const contract = getBuolasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getBuolasContract();
     const response = await contract.methods
       .mapLockedBalances(account)
       .call();
@@ -247,10 +237,9 @@ export const fetchMapLockedBalances = () => async (dispatch, getState) => {
 
 export const fetchLockedEnd = () => async (dispatch, getState) => {
   const account = getState()?.setup?.account;
-  const chainId = getState()?.setup?.chainId;
 
   try {
-    const contract = getBuolasContract(window.MODAL_PROVIDER, chainId);
+    const contract = getBuolasContract();
     const response = await contract.methods
       .lockedEnd(account)
       .call();


### PR DESCRIPTION
* Removes the provider being passed on every contract call and instead uses a common function called `getMyProvider` (please test on Ethereum network)