### PR TITLE
Fix allowance check in hasSufficientTokensRequest function

### DIFF
--- a/components/Home/VeOlas/contractUtils.jsx
+++ b/components/Home/VeOlas/contractUtils.jsx
@@ -85,9 +85,9 @@ export const hasSufficientTokensRequest = ({ account, chainId, amount }) => new 
     .then((response) => {
       const responseInBg = ethers.BigNumber.from(response);
       const amountInBg = ethers.utils.parseUnits(`${amount}`);
-
-      // check if the allowance is greater than the amount input
-      resolve(responseInBg.gt(amountInBg));
+      
+      // check if the allowance is greater than or equal to the amount input
+      resolve(responseInBg.gte(amountInBg));
     })
     .catch((e) => {
       window.console.log('Error occured on calling `allowance` method');

--- a/components/Home/VeOlas/contractUtils.jsx
+++ b/components/Home/VeOlas/contractUtils.jsx
@@ -85,7 +85,7 @@ export const hasSufficientTokensRequest = ({ account, chainId, amount }) => new 
     .then((response) => {
       const responseInBg = ethers.BigNumber.from(response);
       const amountInBg = ethers.utils.parseUnits(`${amount}`);
-      
+
       // check if the allowance is greater than or equal to the amount input
       resolve(responseInBg.gte(amountInBg));
     })


### PR DESCRIPTION
I'm not sure if this will resolve [the issue](https://trello.com/c/NKMffOkr/1386-%F0%9F%9A%A8-locking-allowance-issue) – it might – but it looks quite clearly like a typo to me.

Example situation – I try to lock my full balance – 15 OLAS. The UI shows me an approve step:
<img width="1512" alt="image" src="https://github.com/valory-xyz/autonolas-member-frontend/assets/66292936/a3b9cad2-1875-4684-9ad0-bbd5afe4643a">

This is wrong. I have already approved 15 OLAS:
<img width="392" alt="image" src="https://github.com/valory-xyz/autonolas-member-frontend/assets/66292936/bdb31f6d-8088-44f8-8d7b-59490e355d10">

The cause of this issue seems quite simple – we are using a greater than check, when we need a greater than or equal to.
